### PR TITLE
Changing Snackbar Text Visibility  in Dark Mode on About Page 

### DIFF
--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -10,6 +10,9 @@ class MyTheme {
           secondary: Colors.white,
           brightness: Brightness.light,
         ),
+     snackBarTheme: const SnackBarThemeData(
+            backgroundColor: Colors.black,
+            contentTextStyle: TextStyle(color: Colors.white)),
         textTheme: GoogleFonts.poppinsTextTheme(ThemeData.light().textTheme),
         appBarTheme: const AppBarTheme(
           color: Colors.white,
@@ -26,6 +29,9 @@ class MyTheme {
           secondary: Colors.white,
           brightness: Brightness.dark,
         ),
+     snackBarTheme: const SnackBarThemeData(
+            backgroundColor: Colors.white,
+            contentTextStyle: TextStyle(color: Colors.black)),
         textTheme: GoogleFonts.poppinsTextTheme(ThemeData.dark().textTheme),
         appBarTheme: const AppBarTheme(
           color: Colors.white,


### PR DESCRIPTION



Changes Made:

updated the theme.dart file by adding snackbarthemedata widget on light and dark mode. With this, the text in snackbar will be visible in dark mode too. 

Related Issue:

Snackbar Text Visibility Issue in Dark Mode on About Page #224

Screenshots/GIFs:

![snackbar1](https://github.com/Clueless-Community/Spectrum-UI/assets/117339714/420d53f3-cf73-44ed-8779-65cad9065e84)
![snackbar2](https://github.com/Clueless-Community/Spectrum-UI/assets/117339714/53f354c8-61ca-4b65-92cb-8d1fa451e184)


Please review and merge this PR at your earliest convenience.

Thank you!

